### PR TITLE
Add Forbidden Error rescue to post tweet

### DIFF
--- a/app/controllers/twitter_controller.rb
+++ b/app/controllers/twitter_controller.rb
@@ -43,10 +43,10 @@ class TwitterController < ApplicationController
       end
     end
 
-    render nothing: true, status: 200 and return
-
   rescue Twitter::Error::Forbidden => e
 
+  ensure
+    render nothing: true, status: 200 and return
   end
 
   def update

--- a/app/controllers/twitter_controller.rb
+++ b/app/controllers/twitter_controller.rb
@@ -44,6 +44,9 @@ class TwitterController < ApplicationController
     end
 
     render nothing: true, status: 200 and return
+
+  rescue Twitter::Error::Forbidden => e
+
   end
 
   def update


### PR DESCRIPTION
This PR adds a Twitter::Error::Forbidden rescue clause to Twitter#post_tweet to avoid crashes: 
- https://app.honeybadger.io/projects/39766/faults/33615513#notice-summary